### PR TITLE
Improved cryptsetup section clarity by renaming decrypted device name

### DIFF
--- a/cv03-pam-lvm-luks-ca/manual.md
+++ b/cv03-pam-lvm-luks-ca/manual.md
@@ -83,7 +83,7 @@ $ mount /dev/mapper/decrypted /mnt
 ### Persistetni pouziti
 
 ```bash
-/etc/cryptotab
+/etc/crypttab
 /etc/fstab
 ```
 

--- a/cv03-pam-lvm-luks-ca/manual.md
+++ b/cv03-pam-lvm-luks-ca/manual.md
@@ -70,9 +70,14 @@ $ lvcreate -L 1G -n test vgbsa
 
 ```bash
 $ cryptsetup -y -v luksFormat /dev/vgbsa/test
-$ cryptsetup luksOpen /dev/vgbsa/test crypted
-$ mkfs.ext4 /dev/mapper/crypted
-$ mount /dev/mapper/crypted /mnt
+```
+
+`/dev/vgbsa/test` je nyní šifrované, otevřeme nad ním dešifrované rozhraní `decrypted`
+
+```bash
+$ cryptsetup luksOpen /dev/vgbsa/test decrypted
+$ mkfs.ext4 /dev/mapper/decrypted
+$ mount /dev/mapper/decrypted /mnt
 ```
 
 ### Persistetni pouziti


### PR DESCRIPTION
- it is confusing for a decrypted device to be named `crypted`
- renaming it to `decrypted` improves clarity and is then easier for user to read and understand
- fixed a typo
    - `/etc/cryptotab` changed to `/etc/crypttab`, since the first is not a valid `cryptsetup` configuration file